### PR TITLE
Fixed base interpolator to  android.view.animation.Interpolator  instead of TimeInterpolator to support apis which accepts an Interpolator, eg. OverScroller.

### DIFF
--- a/ei/src/main/java/com/daasuu/ei/EasingInterpolator.java
+++ b/ei/src/main/java/com/daasuu/ei/EasingInterpolator.java
@@ -1,13 +1,14 @@
 package com.daasuu.ei;
 
-import android.animation.TimeInterpolator;
+import android.view.animation.Interpolator;
+
 import androidx.annotation.NonNull;
 
 /**
  * The Easing class provides a collection of ease functions. It does not use the standard 4 param
  * ease signature. Instead it uses a single param which indicates the current linear ratio (0 to 1) of the tween.
  */
-public class EasingInterpolator implements TimeInterpolator {
+public class EasingInterpolator implements Interpolator {
 
     private final Ease ease;
 


### PR DESCRIPTION
TimeInterpolator was introduced in API 11 which restricts EasingInterpolator to be used only with new APIs, so changed TimeInterpolator to `android.view.animation.Interpolator` in order to allow using EasingInterpolator with APIs which needs an instace of Interpolator instead of TimeInterpolator.